### PR TITLE
Add subnet creation to the VPC module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,30 +1,39 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-  required_version =  ">= 1.1.0"
-}
-
-# Configure the AWS Provider
-provider "aws" {
-  region = "us-east-1"
-}
-
 # Create a VPC
 resource "aws_vpc" "main" {
-  cidr_block = var.vpc_cidr_range
-  instance_tenancy = var.vpc_instance_tenancy
-  enable_dns_support = true  # globally enforced across the organisation
-  enable_dns_hostnames  = true # globally enforced across the organisation
-  
+  cidr_block           = var.vpc_cidr_range
+  instance_tenancy     = var.vpc_instance_tenancy
+  enable_dns_support   = true # globally enforced across the organisation
+  enable_dns_hostnames = true # globally enforced across the organisation
 
-# Associate relevant tags for the VPC
-tags = {
-    Name = var.vpc_name
-    Environment = var.vpc_environment
-    BusinessUnit = var.vpc_business_unit
+
+  # Associate relevant tags for the VPC
+  tags = local.mandatory_tags
 }
+
+locals {
+  mandatory_tags = merge({
+    Name         = var.vpc_name
+    Environment  = var.vpc_environment
+    BusinessUnit = var.vpc_business_unit
+  })
+}
+
+# Create the public subnet
+resource "aws_subnet" "public_subnet" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true # instances launched into this subnet will be assigned a public IP address
+
+  # Associate relevant tags for the Public Subnet
+  tags = local.mandatory_tags
+}
+
+# Create the private subnet
+resource "aws_subnet" "private_subnet" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = var.private_subnet_cidr
+
+  # Associate relevant tags for the Private Subnet. 
+  # For simplicity, here, the VPC, Public and Private Subnets share the same tags, but resource specific tags can also be added.
+  tags = local.mandatory_tags
 }


### PR DESCRIPTION
This module was originally intended to create only the VPC, with subnets being created as part of a separate module.
For consolidation and simplicity purposes, this module is now being updated to deploy both the VPC as well as a public and private subnet together. 